### PR TITLE
Extract categorical feature identification & add cat_features to catboost

### DIFF
--- a/R/catboost.R
+++ b/R/catboost.R
@@ -194,6 +194,25 @@ add_boost_tree_catboost <- function() {
   )
 }
 
+prepare_df_catboost <- function(x, y = NULL) {
+  categorical_cols <- categorical_columns(x)
+  x <- categorical_features_to_int(x, categorical_cols)
+  x <- as.matrix(x)
+
+  # catboost uses 0-indexed feature cols
+  if(!is.null(categorical_cols)){categorical_cols <- categorical_cols-1}
+
+  if (is.null(y))
+    return(x)
+
+  catboost::catboost.load_pool(
+    data = as.matrix(x),
+    label = y,
+    cat_features = categorical_cols
+  )
+}
+
+
 #' Boosted trees via catboost
 #'
 #' `catboost_train` is a wrapper for `catboost` tree-based models
@@ -252,7 +271,7 @@ train_catboost <- function(x, y, depth = 6, iterations = 1000, learning_rate = N
   )
 
   # train ------------------------
-  d <- catboost::catboost.load_pool(data = x, label = y)
+  d <- prepare_df_catboost(x,y)
 
   # override or add some other args
   others <- list(...)

--- a/R/catboost.R
+++ b/R/catboost.R
@@ -194,10 +194,12 @@ add_boost_tree_catboost <- function() {
   )
 }
 
-prepare_df_catboost <- function(x, y = NULL) {
-  categorical_cols <- categorical_columns(x)
-  x <- categorical_features_to_int(x, categorical_cols)
-  x <- as.matrix(x)
+prepare_df_catboost <- function(x, y = NULL, categorical_cols= NULL) {
+  if(is.null(categorical_cols)){
+    # auto detect the categorical columns from data.frame
+    # Not strictly necessary but good form.
+    categorical_cols <- categorical_columns(x)
+  }
 
   # catboost uses 0-indexed feature cols
   if(!is.null(categorical_cols)){categorical_cols <- categorical_cols-1}
@@ -206,7 +208,7 @@ prepare_df_catboost <- function(x, y = NULL) {
     return(x)
 
   catboost::catboost.load_pool(
-    data = as.matrix(x),
+    data = x,
     label = y,
     cat_features = categorical_cols
   )

--- a/R/catboost.R
+++ b/R/catboost.R
@@ -229,12 +229,14 @@ prepare_df_catboost <- function(x, y = NULL, categorical_cols= NULL) {
 #' @param min_data_in_leaf A numeric value for the minimum sum of instances needed
 #'  in a child to continue to split.
 #' @param subsample Subsampling proportion of rows.
+#' @param categorical_cols indices of categorical columns, when NULL (default) factor columns are automatically detected
 #' @param ... Other options to pass to `catboost.train`.
 #' @return A fitted `catboost.Model` object.
 #' @keywords internal
 #' @export
 train_catboost <- function(x, y, depth = 6, iterations = 1000, learning_rate = NULL,
-                           rsm = 1, min_data_in_leaf = 1, subsample = 1, ...) {
+                           rsm = 1, min_data_in_leaf = 1, subsample = 1,
+                           categorical_cols = NULL, ...) {
 
   # rsm ------------------------------
   if(!is.null(rsm)) {
@@ -273,7 +275,7 @@ train_catboost <- function(x, y, depth = 6, iterations = 1000, learning_rate = N
   )
 
   # train ------------------------
-  d <- prepare_df_catboost(x,y)
+  d <- prepare_df_catboost(x, y = y, categorical_cols = categorical_cols)
 
   # override or add some other args
   others <- list(...)
@@ -303,10 +305,11 @@ train_catboost <- function(x, y, depth = 6, iterations = 1000, learning_rate = N
 #' @param new_data A rectangular data object, such as a data frame.
 #' @param type A single character value or NULL. Possible values are "numeric", "class", "prob", "conf_int", "pred_int", "quantile", or "raw". When NULL, predict() will choose an appropriate value based on the model's mode.
 #' @param trees An integer vector for the number of trees in the ensemble.
+#' @param categorical_cols indices of categorical columns, when NULL (default) factor columns are automatically detected.
 #'
 #' @export
 #' @importFrom purrr map_df
-multi_predict._catboost.Model <- function(object, new_data, type = NULL, trees = NULL, ...) {
+multi_predict._catboost.Model <- function(object, new_data, type = NULL, trees = NULL, categorical_cols = NULL, ...) {
     if (any(names(rlang::enquos(...)) == "newdata")) {
       rlang::abort("Did you mean to use `new_data` instead of `newdata`?")
     }
@@ -330,8 +333,8 @@ multi_predict._catboost.Model <- function(object, new_data, type = NULL, trees =
         "prob" = "Probability"
       )
     }
-
-    res <- map_df(trees, catboost_by_tree, object = object, new_data = new_data, type = type, ...)
+    d <- prepare_df_catboost(new_data,y, categorical_cols = categorical_cols)
+    res <- map_df(trees, catboost_by_tree, object = object, new_data = d, type = type, ...)
     res <- dplyr::arrange(res, .row, trees)
     res <- split(res[, -1], res$.row)
     names(res) <- NULL
@@ -340,9 +343,9 @@ multi_predict._catboost.Model <- function(object, new_data, type = NULL, trees =
 
   }
 
-catboost_by_tree <- function(tree, object, new_data, type, ...) {
-
-  pred <- predict.catboost.Model(object$fit, new_data, ntree_end = tree, type = type, ...)
+catboost_by_tree <- function(tree, object, new_data, type, categorical_cols = NULL,...) {
+  d <- prepare_df_catboost(new_data, categorical_cols = categorical_cols)
+  pred <- predict.catboost.Model(object$fit, d, ntree_end = tree, type = type, categorical_columns=categorical_columns,...)
 
   # switch based on prediction type
   if (object$spec$mode == "regression") {
@@ -365,10 +368,11 @@ catboost_by_tree <- function(tree, object, new_data, type, ...) {
 }
 
 #' @export
-predict.catboost.Model <- function(object, new_data, type = "RawFormulaVal", ...) {
+predict.catboost.Model <- function(object, new_data, type = "RawFormulaVal",categorical_cols = NULL, ...) {
 
   if (!inherits(new_data, "catboost.Pool")) {
-    new_data <- catboost::catboost.load_pool(new_data)
+    d <- prepare_df_catboost(new_data, categorical_cols = categorical_cols)
+    new_data <- catboost::catboost.load_pool(d)
   }
 
   type <- switch (

--- a/R/lightgbm.R
+++ b/R/lightgbm.R
@@ -157,14 +157,9 @@ add_boost_tree_lightgbm <- function() {
   )
 }
 
-prepare_df <- function(x, y = NULL) {
-  categorical_cols <- NULL
-  for (i in seq_along(x)) {
-    if (is.factor(x[[i]])) {
-      x[[i]] <- as.integer(x[[i]]) - 1L
-      categorical_cols <- c(categorical_cols, i)
-    }
-  }
+prepare_df_lgbm <- function(x, y = NULL) {
+  categorical_cols <- categorical_columns(x)
+  x <- categorical_features_to_int(x, categorical_cols)
   x <- as.matrix(x)
 
   if (is.null(y))
@@ -260,7 +255,7 @@ train_lightgbm <- function(x, y, max_depth = 6, num_iterations = 100, learning_r
 
 
   # train ------------------------
-  d <- prepare_df(x, y)
+  d <- prepare_df_lgbm(x, y)
 
   main_args <- list(
     data = quote(d),
@@ -281,7 +276,7 @@ train_lightgbm <- function(x, y, max_depth = 6, num_iterations = 100, learning_r
 #'
 #' @export
 predict_lightgbm_classification_prob <- function(object, new_data) {
-  p <- stats::predict(object$fit, prepare_df(new_data), reshape = TRUE)
+  p <- stats::predict(object$fit, prepare_df_lgbm(new_data), reshape = TRUE)
   if(is.vector(p)) {
     p <- tibble::tibble(p1 = 1 - p, p2 = p)
   }
@@ -299,7 +294,7 @@ predict_lightgbm_classification_prob <- function(object, new_data) {
 #'
 #' @export
 predict_lightgbm_classification_class <- function(object, new_data) {
-  p <- predict_lightgbm_classification_prob(object, prepare_df(new_data))
+  p <- predict_lightgbm_classification_prob(object, prepare_df_lgbm(new_data))
   q <- apply(p, 1, function(x) which.max(x))
   names(p)[q]
 }
@@ -315,7 +310,7 @@ predict_lightgbm_classification_class <- function(object, new_data) {
 #'
 #' @export
 predict_lightgbm_regression_numeric <- function(object, new_data) {
-  p <- stats::predict(object$fit, prepare_df(new_data), reshape = TRUE)
+  p <- stats::predict(object$fit, prepare_df_lgbm(new_data), reshape = TRUE)
   p
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,0 +1,26 @@
+#' Retrieve the indices of categorical (factor) columns
+#'
+#' Utility function to help identify factors in data.frame.
+#' Does only identify the columns, nothing else.
+#' @noRd
+categorical_columns <- function(x){
+  categorical_cols <- NULL
+  for (i in seq_along(x)) {
+    if (is.factor(x[[i]])) {
+      categorical_cols <- c(categorical_cols, i)
+    }
+  }
+  categorical_cols
+}
+
+#' Replace categorical features with integers
+#'
+#' Utility function to replace categorical features with integer
+#' representation.
+#' @noRd
+categorical_features_to_int <- function(x, cat_indices){
+  for (i in cat_indices){
+    x[[i]] <- as.integer(x[[i]]) -1
+  }
+  x
+}

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,0 +1,38 @@
+test_that("categorical features are identified in data.frames and tibbles",{
+  test_frame <- data.frame(
+    num1 = 1:10,
+    cat1 = letters[1:10],
+    num2 = 10:10,
+    cat2 = letters[10:1],
+    stringsAsFactors = TRUE
+  )
+  test_frame2 <- tibble::as_tibble(test_frame)
+  expect_equal(
+    categorical_columns(test_frame),
+    c(2,4)
+  )
+  expect_equal(
+    categorical_columns(test_frame2),
+    c(2,4)
+  )
+})
+
+test_that("categorical features are replaced with integers",{
+  test_frame <- data.frame(
+    num1 = 1:10,
+    cat1 = letters[1:10],
+    num2 = 10:10,
+    cat2 = letters[10:1],
+    stringsAsFactors = TRUE
+  )
+  expected <- data.frame(
+    num1 = 1:10,
+    cat1 = 0:9,
+    num2 = 10:10,
+    cat2 = 9:0
+  )
+  expect_equal(
+    categorical_features_to_int(test_frame, c(2,4)),
+    expected
+  )
+})


### PR DESCRIPTION
Hi there! I have a small proposal and I hope you consider it.  Greetings, Roel

In this PR 
Commit1 : I extract the categorical column identification function, split it into two separate functions: one for detection and one for replacement of factors with integers. 
I think (and I leave it for you to decide if that is true) it is better to have the two things pulled apart. It is easier to test the functionality and we reuse the functions. Also because catboost apperantly uses 0-indexed columns, the categorical indices are easily modified for catboost vs lightgbm while the underlying logic remains unduplicated. 

commit2: Add categorical features to catboost and replace the categorical functionality currently present in lightgbm. I also added the same type of prepare_df functionality in catboost like lightgm so the two are more comparable. 