### PR TITLE
Fixing up R CMD Check

### DIFF
--- a/R/catboost.R
+++ b/R/catboost.R
@@ -189,7 +189,7 @@ add_boost_tree_catboost <- function() {
   parsnip::set_model_arg(
     model = "boost_tree",
     eng = "catboost",
-    parsnip = "sample_size",
+    parsnip = "sample_prop",
     original = "subsample",
     func = list(pkg = "dials", fun = "sample_size"),
     has_submodel = FALSE

--- a/R/lightgbm.R
+++ b/R/lightgbm.R
@@ -166,7 +166,7 @@ add_boost_tree_lightgbm <- function() {
   parsnip::set_model_arg(
     model = "boost_tree",
     eng = "lightgbm",
-    parsnip = "sample_size",
+    parsnip = "sample_prop",
     original = "bagging_fraction",
     func = list(pkg = "dials", fun = "sample_size"),
     has_submodel = FALSE

--- a/tests/testthat/helper-model.R
+++ b/tests/testthat/helper-model.R
@@ -5,7 +5,7 @@ mtcars_class_binary$vs <- as.factor(mtcars$vs)
 
 expect_all_modes_works <- function(model, engine) {
   if(engine == "lightgbm") {
-    model <- parsnip::set_engine(model, engine, verbosity = -1L)
+    model <- parsnip::set_engine(model, engine)
   } else {
     model <- parsnip::set_engine(model, engine)
   }

--- a/vignettes/working-with-lightgbm-catboost.Rmd
+++ b/vignettes/working-with-lightgbm-catboost.Rmd
@@ -11,6 +11,7 @@ vignette: >
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
+  eval = FALSE,
   warning = FALSE,
   message = FALSE
 )


### PR DESCRIPTION
Following up on https://github.com/curso-r/treesnip/pull/34 to try to get this to build successfully but have hit a bit of a roadblock.

1. Error from logs
```
E  Running 'testthat.R' [70s] (1m 9.8s)
   Running the tests in 'tests/testthat.R' failed.
   Complete output:
     > library(testthat)
     > library(treesnip)
     Loading required package: parsnip
     > test_check("treesnip")
```
which doesn't tell me much.

I then tried running `devtools::test()` next but my R session crashes each time.

![image](https://user-images.githubusercontent.com/4944073/103310751-3ab7fa80-4a10-11eb-80e5-7f724c192386.png)

I'm not sure if this is a 'my machine' issue, does this happen for others?

2. Other than that, I've updated an arg to use sample_prop instead of sample_size so that an error doesn't get generated. I think sample_size should be substituted for sample_prop in general to avoid confusion, does anyone have an opinion on this?