### PR TITLE
remove feature_pre_filter from lgb.Dataset

### DIFF
--- a/R/lightgbm.R
+++ b/R/lightgbm.R
@@ -271,8 +271,7 @@ train_lightgbm <- function(x, y, max_depth = 17, num_iterations = 10, learning_r
   d <- lightgbm::lgb.Dataset(
     data = prepare_df_lgbm(x),
     label = y,
-    categorical_feature = categorical_columns(x),
-    feature_pre_filter = FALSE
+    categorical_feature = categorical_columns(x)
   )
 
   main_args <- list(


### PR DESCRIPTION
I suggest removing the cause of the error.
A warning from the lightGBM package, which may stop as an error in the future.